### PR TITLE
[kamino] temporary disable kamino for etl parsing

### DIFF
--- a/scraper/buildspec.yaml
+++ b/scraper/buildspec.yaml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    TAG: 2023e91
+    TAG: 317ac5b
     REGION: eu-central-1
   parameter-store:
     POSTGRES_URL: /marinade/solana-snapshot-manager/db/prod

--- a/src/snapshot/parser/parser.service.ts
+++ b/src/snapshot/parser/parser.service.ts
@@ -116,7 +116,8 @@ export class ParserService {
     yield [this.mrgn(db), Source.MRGN];
     yield [this.mango(db), Source.MANGO];
     yield [this.lifinity(db), Source.LIFINITY];
-    yield [await this.kamino(db, slot), Source.KAMINO];
+    // TODO: temporary disable of kamino processing
+    // yield [await this.kamino(db, slot), Source.KAMINO];
   }
 
   async *parseVeMNDERecords(
@@ -203,9 +204,12 @@ export class ParserService {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getVaults(db: SQLite.Database, slot: number): Promise<string[]> {
-    const staticVaults = vaults;
-    return [...staticVaults, ...(await this.getKaminoVaults(db, slot))];
+    // TODO: temporary disable of kamino processing
+    // const staticVaults = vaults;
+    // return [...staticVaults, ...(await this.getKaminoVaults(db, slot))];
+    return vaults;
   }
 
   async *parse(sqlite: string, slot: number): AsyncGenerator<SnapshotRecord> {


### PR DESCRIPTION
Reverting etl processing in pipeline to prior docker image `317ac5b`.