### PR TITLE
[parser pipeline] not using memory mapped io in etl + using transactions

### DIFF
--- a/scraper/buildspec.yaml
+++ b/scraper/buildspec.yaml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    TAG: b0da402
+    TAG: 2023e91
     REGION: eu-central-1
   parameter-store:
     POSTGRES_URL: /marinade/solana-snapshot-manager/db/prod
@@ -30,7 +30,7 @@ phases:
       - "SLOT=$(tar -tf /data/snapshot.tar.bz2 | head -n 5 | grep ^snapshots/.*/ | cut -d/ -f2 | uniq | head -n1)"
       - pnpm install --frozen-lockfile
       - pnpm run cli -- filters --json-output filters.json
-      - docker run --rm --volume "/data:/data" --volume "$(realpath ./filters.json):/filters.json:ro" "$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/marinade.finance/snapshot-etl:$TAG" /usr/local/bin/solana-snapshot-etl /data/snapshot.tar.bz2 --sqlite-out /data/snapshot.db
+      - docker run --rm --volume "/data:/data" --volume "$(realpath ./filters.json):/filters.json:ro" "$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/marinade.finance/snapshot-etl:$TAG" /usr/local/bin/solana-snapshot-etl /data/snapshot.tar.bz2 --sqlite-out /data/snapshot.db --sqlite-tx-bulk 2000
       - ./index-db.bash /data/snapshot.db
       - pnpm run cli -- parse --sqlite /data/snapshot.db --csv-output /data/snapshot.csv --slot "$SLOT --psql-output"
       - pnpm run cli -- record-msol-votes


### PR DESCRIPTION
http://localhost:8080/job/solana-snapshot-etl/26/console

```
+ ./jenkins/ci-utils/update-container-versions.bash 400405091548.dkr.ecr.eu-central-1.amazonaws.com/marinade.finance/snapshot-etl 2023e91 prod */argocd/***.yaml
Replacing tag of all occurences of image 400405091548\.dkr\.ecr\.eu-central-1\.amazonaws\.com\/marinade\.finance\/snapshot-etl:... in environment prod with 2023e91
```