### PR TITLE
Kamino parsing fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@coral-xyz/anchor": "0.28.1-beta.1",
     "@hubbleprotocol/scope-sdk": "^2.2.18",
     "@marinade.finance/directed-stake-sdk": "^0.0.4",
-    "@hubbleprotocol/kamino-sdk": "^2.2.41",
+    "@hubbleprotocol/kamino-sdk": "^2.2.48",
     "@mercurial-finance/vault-sdk": "0.5.1",
     "@nestjs/cache-manager": "^1.0.0",
     "@nestjs/common": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 0.28.1-beta.1
     version: 0.28.1-beta.1
   '@hubbleprotocol/kamino-sdk':
-    specifier: ^2.2.41
-    version: 2.2.41(@solana/web3.js@1.75.0)(decimal.js@10.4.3)
+    specifier: ^2.2.48
+    version: 2.2.48(@solana/web3.js@1.75.0)(decimal.js@10.4.3)
   '@hubbleprotocol/scope-sdk':
     specifier: ^2.2.18
     version: 2.2.18(@solana/web3.js@1.75.0)(decimal.js@10.4.3)
@@ -111,7 +111,7 @@ devDependencies:
     version: 9.3.0
   '@nestjs/schematics':
     specifier: ^9.0.0
-    version: 9.1.0(typescript@4.9.5)
+    version: 9.1.0(chokidar@3.5.3)(typescript@4.9.5)
   '@nestjs/testing':
     specifier: ^9.0.0
     version: 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/platform-express@9.4.0)
@@ -201,22 +201,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
-  /@angular-devkit/core@15.2.4:
-    resolution: {integrity: sha512-yl+0j1bMwJLKShsyCXw77tbJG8Sd21+itisPLL2MgEpLNAO252kr9zG4TLlFRJyKVftm2l1h78KjqvM5nbOXNg==}
-    engines: {node: ^14.20.0 || ^16.13.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    peerDependencies:
-      chokidar: ^3.5.2
-    peerDependenciesMeta:
-      chokidar:
-        optional: true
-    dependencies:
-      ajv: 8.12.0
-      ajv-formats: 2.1.1
-      jsonc-parser: 3.2.0
-      rxjs: 6.6.7
-      source-map: 0.7.4
-    dev: true
-
   /@angular-devkit/core@15.2.4(chokidar@3.5.3):
     resolution: {integrity: sha512-yl+0j1bMwJLKShsyCXw77tbJG8Sd21+itisPLL2MgEpLNAO252kr9zG4TLlFRJyKVftm2l1h78KjqvM5nbOXNg==}
     engines: {node: ^14.20.0 || ^16.13.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -245,19 +229,6 @@ packages:
       inquirer: 8.2.4
       symbol-observable: 4.0.0
       yargs-parser: 21.1.1
-    transitivePeerDependencies:
-      - chokidar
-    dev: true
-
-  /@angular-devkit/schematics@15.2.4:
-    resolution: {integrity: sha512-/W7/vvn59PAVLzhcvD4/N/E8RDhub8ny1A7I96LTRjC5o+yvVV16YJ4YJzolrRrIEN01KmLVQJ9A58VCaweMgw==}
-    engines: {node: ^14.20.0 || ^16.13.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    dependencies:
-      '@angular-devkit/core': 15.2.4
-      jsonc-parser: 3.2.0
-      magic-string: 0.29.0
-      ora: 5.4.1
-      rxjs: 6.6.7
     transitivePeerDependencies:
       - chokidar
     dev: true
@@ -998,15 +969,15 @@ packages:
     resolution: {integrity: sha512-hI4TIbzo3VsuC+faELoyak/SSr/i4Zg9qHVM5OwyvRvB01Loob5FRrKn0cUpAo5T0H+KR1LwrIHAR8lFUzINvg==}
     dev: false
 
-  /@hubbleprotocol/kamino-sdk@2.2.41(@solana/web3.js@1.75.0)(decimal.js@10.4.3):
-    resolution: {integrity: sha512-r52oUXzzAKB2a1i9pL7+3sT/JGTuNpXVbCpKBuDZIdQhi2VdUHrF6vcxZ8moRiS6atx+bFaqvcoU7ZZju2775w==}
+  /@hubbleprotocol/kamino-sdk@2.2.48(@solana/web3.js@1.75.0)(decimal.js@10.4.3):
+    resolution: {integrity: sha512-LoKwDLwC/DE4BKR02y/i/gBZ6nAwJluWF1DIJKKrSDhEBnouF3xTpxKEwqtK9YFNfXUkL9fqtfE//L8J6//szg==}
     peerDependencies:
       '@solana/web3.js': ~1.78.4
       decimal.js: ^10.3.1
     dependencies:
       '@hubbleprotocol/hubble-config': 2.1.0(@solana/web3.js@1.75.0)
       '@hubbleprotocol/hubble-idl': 2.2.40
-      '@hubbleprotocol/scope-sdk': 2.2.34(@solana/web3.js@1.75.0)(decimal.js@10.4.3)
+      '@hubbleprotocol/scope-sdk': 2.2.48(@solana/web3.js@1.75.0)(decimal.js@10.4.3)
       '@jup-ag/api': 6.0.6
       '@jup-ag/core': 3.0.0-beta.18(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.75.0)
       '@orca-so/sdk': 1.2.26
@@ -1052,8 +1023,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@hubbleprotocol/scope-sdk@2.2.34(@solana/web3.js@1.75.0)(decimal.js@10.4.3):
-    resolution: {integrity: sha512-PV3fsbw1lDd/PStv9HCtUc/yzBDBLOx43Q1miCTkfw5NyyIs6TmaoO5dx3+ur1YdaESmqhH/P3on8Bj8p1iKXA==}
+  /@hubbleprotocol/scope-sdk@2.2.48(@solana/web3.js@1.75.0)(decimal.js@10.4.3):
+    resolution: {integrity: sha512-ibH6Jqdx3J2I5ZzSuQ7rgeQkO/3nEklixPZxmetXJcX3B9Y5HcxUBYf3gmM0Ev89Z5ISwKMHEeMlHzcUhc9mcw==}
     peerDependencies:
       '@solana/web3.js': ^1.78.4
       decimal.js: ^10.3.1
@@ -1410,7 +1381,7 @@ packages:
       '@jup-ag/whirlpools-sdk': 0.7.2
       '@mercurial-finance/dynamic-amm-sdk': 0.1.9(@solana/buffer-layout@4.0.1)
       '@mercurial-finance/optimist': 0.1.9(@solana/spl-token@0.1.8)(@solana/web3.js@1.75.0)(bn.js@5.2.1)
-      '@mercurial-finance/vault-sdk': 0.3.2
+      '@mercurial-finance/vault-sdk': 0.3.2(@saberhq/token-utils@1.13.32)
       '@noble/hashes': 1.1.2
       '@project-serum/anchor': 0.24.2
       '@project-serum/serum': 0.13.65
@@ -1903,37 +1874,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@mercurial-finance/vault-sdk@0.3.2:
-    resolution: {integrity: sha512-q5mulo3KQKzfC0eqKB83+5oRW0iwR7mje6PDN2Y85cMS4OWpQc7y2uYWN8toVgwQKFfnkomp/mDnuRsgqZHTnw==}
-    dependencies:
-      '@blockworks-foundation/mango-client': 3.6.20
-      '@mercurial-finance/apricot-sdk': 0.17.6
-      '@mercurial-finance/francium-sdk': 1.4.3
-      '@mercurial-finance/optimist': 0.1.9(@solana/spl-token@0.1.8)(@solana/web3.js@1.78.5)(bn.js@5.2.1)
-      '@mercurial-finance/port-sdk': 0.2.69(@solana/web3.js@1.78.5)(bn.js@5.2.1)
-      '@mercurial-finance/solend-sdk': 0.6.5
-      '@mercurial-finance/tulip-platform-sdk': 2.0.30
-      '@project-serum/anchor': 0.24.2
-      '@quarryprotocol/quarry-sdk': 5.0.2(@project-serum/anchor@0.24.2)(@saberhq/anchor-contrib@1.14.11)(@solana/web3.js@1.78.5)(bn.js@5.2.1)(jsbi@4.3.0)
-      '@saberhq/anchor-contrib': 1.14.11(@project-serum/anchor@0.24.2)(@solana/web3.js@1.78.5)(bn.js@5.2.1)
-      '@solana/buffer-layout': 4.0.1
-      '@solana/spl-token': 0.1.8
-      '@solana/spl-token-registry': 0.2.1105
-      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.78.5)
-      '@solana/web3.js': 1.78.5
-      bn.js: 5.2.1
-      cross-fetch: 3.1.5
-      decimal.js: 10.3.1
-      jsbi: 4.3.0
-    transitivePeerDependencies:
-      - '@saberhq/solana-contrib'
-      - '@saberhq/token-utils'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
-
   /@mercurial-finance/vault-sdk@0.3.2(@saberhq/token-utils@1.13.32):
     resolution: {integrity: sha512-q5mulo3KQKzfC0eqKB83+5oRW0iwR7mje6PDN2Y85cMS4OWpQc7y2uYWN8toVgwQKFfnkomp/mDnuRsgqZHTnw==}
     dependencies:
@@ -2254,20 +2194,6 @@ packages:
     dependencies:
       '@angular-devkit/core': 15.2.4(chokidar@3.5.3)
       '@angular-devkit/schematics': 15.2.4(chokidar@3.5.3)
-      jsonc-parser: 3.2.0
-      pluralize: 8.0.0
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - chokidar
-    dev: true
-
-  /@nestjs/schematics@9.1.0(typescript@4.9.5):
-    resolution: {integrity: sha512-/7CyMTnPJSK9/xD9CkCqwuHPOlHVlLC2RDnbdCJ7mIO07SdbBbY14msTqtYW9VRQtsjZPLh1GTChf7ryJUImwA==}
-    peerDependencies:
-      typescript: '>=4.3.5'
-    dependencies:
-      '@angular-devkit/core': 15.2.4
-      '@angular-devkit/schematics': 15.2.4
       jsonc-parser: 3.2.0
       pluralize: 8.0.0
       typescript: 4.9.5
@@ -3039,27 +2965,6 @@ packages:
       '@project-serum/anchor': 0.24.2
       '@saberhq/anchor-contrib': 1.14.11(@project-serum/anchor@0.24.2)(@solana/web3.js@1.78.5)(bn.js@5.2.1)
       '@saberhq/token-utils': 1.13.32(@solana/web3.js@1.78.5)(bn.js@5.2.1)(jsbi@4.3.0)
-      '@solana/web3.js': 1.78.5
-      bn.js: 5.2.1
-      jsbi: 4.3.0
-      superstruct: 0.15.5
-      tiny-invariant: 1.3.1
-      tslib: 2.5.0
-    dev: false
-
-  /@quarryprotocol/quarry-sdk@5.0.2(@project-serum/anchor@0.24.2)(@saberhq/anchor-contrib@1.14.11)(@solana/web3.js@1.78.5)(bn.js@5.2.1)(jsbi@4.3.0):
-    resolution: {integrity: sha512-wczlmNfb8fk6WCZsLLR7ysSjgxl6ZdEJ7cNDhgvFpU9E1YMSN1f2l2NK9yw+VksuLxWCightFsBrHSqqIftDzQ==}
-    peerDependencies:
-      '@project-serum/anchor': '>=0.19'
-      '@saberhq/anchor-contrib': ^1.12
-      '@saberhq/solana-contrib': ^1.12
-      '@saberhq/token-utils': ^1.12
-      '@solana/web3.js': ^1
-      bn.js: ^5.2.0
-      jsbi: ^3 || ^4
-    dependencies:
-      '@project-serum/anchor': 0.24.2
-      '@saberhq/anchor-contrib': 1.14.11(@project-serum/anchor@0.24.2)(@solana/web3.js@1.78.5)(bn.js@5.2.1)
       '@solana/web3.js': 1.78.5
       bn.js: 5.2.1
       jsbi: 4.3.0
@@ -4755,7 +4660,7 @@ packages:
   /axios@0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -4772,7 +4677,7 @@ packages:
   /axios@1.3.6:
     resolution: {integrity: sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -4782,7 +4687,7 @@ packages:
   /axios@1.5.1:
     resolution: {integrity: sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -6357,16 +6262,6 @@ packages:
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
-
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
 
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}


### PR DESCRIPTION
Fix for parsing error `Error: Position 41LtAtgCQxR5LiX8zmropfw7JoZA8S2CnswY3UEoNWTk could not be found.` that's stopping the parsing pipeline
(e.g., https://eu-central-1.console.aws.amazon.com/codesuite/codebuild/400405091548/projects/marinade-snapshot/build/marinade-snapshot%3Ad5fc60cb-3c4b-41a2-8be9-3536425de130?region=eu-central-1)

First and foremost, thanks @butonium for fixing with Kamino errors. I'm not sure what was exactly the failure (https://github.com/marinade-finance/solana-snapshot-manager/pull/52). Was it something with number precision?

1) As I was looking what's happening in this case I decided to move the version to new SDK again
2) I was not trying to reproduce the failure while to the deep I was being digging to the root cause the issue is in discrepancy of the states. The `filters.json` freezes the blockchain state to some time and defines what tokens should be loaded during the etl processing. But the `filters.json` operates on different state of the blockchain than the `etl` snapshotting system. This discrepancy means there are differences and account could be removed (or added) in diff time of those two time slots. The Kamino/Orca/Rayidium is pretty dynamic and kind of "complicated" (it's the reason I coded the parsing in way to get all account data as a snapshot and the just use SDK to manage it).
I'm not able to find a good solution until a snapshotting system is changed. I talked with @janlegner about this topic at the Breakpoint last week and this could be all fixed when there is running "an micro validator" offering a state of the blockchain in particular slot and data returned by RPC call can then represent the required state of particular slot.

Until then, I fix a way to load strategies and then workarounding trouble by skipping processing when data misses for a particular strategy. It means not breaking next steps in processing pipeline. I assume two iterations of snapshot processing would not hit an issue with the same strategy (at least logs say so) thus strategy should be just skipped once and next round should manage to load their data again.