### PR TITLE
[buildkite] adding yml script for buildkite

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -1,0 +1,73 @@
+env:
+  DATA_DIR: /mnt/storage-1/solana-snapshot-manager
+  PNPM_HOME: "$$DATA_DIR/pnpm"
+  TAG: 5e8c03a
+  NODE_OPTIONS: --max-old-space-size=8192
+
+agents:
+  queue: "snapshots"
+
+steps:
+  - command: echo "--> Concurrency gate"
+    concurrency_group: 'solana-snapshot-manager/parsing'
+    concurrency: 1
+
+  - wait: ~
+
+  - label: ":drum_with_drumsticks: Preparation"
+    commands:
+    - |
+      echo "Data directory: $$DATA_DIR"
+      mkdir -p "$$DATA_DIR"
+      rm -f "$$DATA_DIR/"*
+
+  - wait: ~
+
+  - label: ":floppy_disk: Downloading snapshot"
+    commands:
+    - |
+      set -x
+      ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+      aws ecr get-login-password --region "$$AWS_DEFAULT_REGION" | docker login --username AWS --password-stdin "$$ACCOUNT_ID.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com"
+      docker pull "$$ACCOUNT_ID.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com/marinade.finance/snapshot-etl:$$TAG"
+      wget --retry-connrefused --waitretry=1 --tries=10 --timeout=30 -q -P "$$DATA_DIR" http://api.mainnet-beta.solana.com/snapshot.tar.bz2
+      buildkite-agent meta-data set account_id "$$ACCOUNT_ID"
+
+  - wait: ~
+
+  - label: ":file_folder: Parsing snapshot"
+    commands:
+    - |
+      set -x
+      account_id=${EPOCH:-$(buildkite-agent meta-data get account_id)}
+      SLOT=$(tar -tf "$$DATA_DIR"/snapshot.tar.bz2 | head -n 5 | grep ^snapshots/.*/ | cut -d/ -f2 | uniq | head -n1)
+      pnpm install --frozen-lockfile
+      pnpm run cli -- filters --json-output filters.json
+      docker run -u $(id -u buildkite-agent) --rm --volume "$$DATA_DIR:/data" --volume "$(realpath ./filters.json):/filters.json:ro" "$$account_id.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com/marinade.finance/snapshot-etl:$$TAG" /usr/local/bin/solana-snapshot-etl /data/snapshot.tar.bz2 --sqlite-out /data/snapshot.db --sqlite-tx-bulk 2000
+      ./index-db.bash "$$DATA_DIR"/snapshot.db
+      pnpm run cli -- parse --sqlite "$$DATA_DIR"/snapshot.db --csv-output "$$DATA_DIR"/snapshot.csv --slot "$$SLOT --psql-output"
+      pnpm run cli -- record-msol-votes
+      buildkite-agent meta-data set slot "$$SLOT"
+
+  - wait: ~
+
+  - label: ":loudspeaker: Notification"
+    commands:
+    - |
+      slot=${EPOCH:-$(buildkite-agent meta-data get slot)}
+      # This hook should be changed for owned by the snapshot manager
+      curl -v "$$DISCORD_WEBHOOK_ETL" -H "Content-Type: application/json" -d '{
+       "username": "Solana Snapshot Manager",
+       "avatar_url": "https://raw.githubusercontent.com/marinade-finance/solana-snapshot-manager/master/scraper/bot.jpg",
+        "embeds": [
+          {
+            "title": "Slot '"$$slot"' has been parsed",
+            "url": "'"$$BUILDKITE_BUILD_URL"'",
+            "color": "16121807"
+          }
+        ]
+      }'
+      
+      
+      
+      


### PR DESCRIPTION
This is an effort to move the snapshot parsing from AWS machine to buildkite managed environment. This was kicked-off by @janlegner .

The benefits is that the run takes ~2 hours against the AWS that takes ~4 hours. The machine there has got 64GB RAM (+ CPU probably) that is considerably better.  The machine is shared with other jobs so the time could be worse when multi tenancy clash happens. But still seems reasonable better. Another benefit is to have a chance to setup notifications. The current bot should be able to post discord messages + failure there should be possible to notify by email or more (need to check later).

I managed to adapt the existing AWS job to buildkite and get it running against the latest snapshot but against `_dev` database. The today's parsing still goes with AWS job.
https://buildkite.com/marinade-finance/marinade-snapshot-manager/builds/19#018c6459-86e4-4857-8ff9-19f3e2b564bd

I would like to ask you @butonium  for review and ideas.