### PR TITLE
[api] logger interceptor to print IP of client

### DIFF
--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -1,0 +1,26 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class IpLoggerInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(IpLoggerInterceptor.name);
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const { headers, url } = request;
+
+    this.logger.log('Request Headers:', {
+      url,
+      requestIp: request.ip,
+      headers,
+    });
+
+    return next.handle();
+  }
+}

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -13,12 +13,13 @@ export class IpLoggerInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
-    const { headers, url } = request;
+    const { url } = request;
+    const cfIp = request.headers['cf-connecting-ip'];
+    const requestIp = cfIp || request.ip;
 
     this.logger.log('Request Headers:', {
       url,
-      requestIp: request.ip,
-      headers,
+      requestIp,
     });
 
     return next.handle();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,14 @@ import { AppModule } from './app.module';
 import { RedocModule, RedocOptions } from 'nestjs-redoc';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from './logger';
+import { IpLoggerInterceptor } from './interceptors/logging.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: new Logger(),
     cors: true,
   });
+  app.useGlobalInterceptors(new IpLoggerInterceptor());
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   const options = new DocumentBuilder()
     .setTitle('Marinade Snapshot API')


### PR DESCRIPTION
Adding (hopefully temporal) an interceptor for logging the IP address of the caller at the endpoint. Plus logging headers coming from the call (e.g., CloudFlare uses the `cf-connecting-ip` to inform who is "behind" the call)