### PR TITLE
[buildkite] reducing requirements for snapshot downloading

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -30,7 +30,7 @@ steps:
     - |
       echo "Data directory: $$DATA_DIR"
       mkdir -p "$$DATA_DIR"
-      rm -f "$$DATA_DIR/"*
+      rm -rf "$$DATA_DIR/"*
 
   - wait: ~
 
@@ -40,10 +40,13 @@ steps:
       set -x -e
       ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
       aws ecr get-login-password --region "$$AWS_DEFAULT_REGION" | docker login --username AWS --password-stdin "$$ACCOUNT_ID.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com"
-      docker pull "$$ACCOUNT_ID.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com/marinade.finance/snapshot-etl:$$TAG"
-      # wget --retry-connrefused --waitretry=1 --tries=10 --timeout=30 -q -P "$$DATA_DIR" http://api.mainnet-beta.solana.com/snapshot.tar.bz2
-      docker run -it --rm -v "$$DATA_DIR":/solana/snapshot --user $(id -u):$(id -g) c29r3/solana-snapshot-finder:latest --snapshot_path /solana/snapshot
       buildkite-agent meta-data set account_id "$$ACCOUNT_ID"
+      docker pull "$$ACCOUNT_ID.dkr.ecr.$$AWS_DEFAULT_REGION.amazonaws.com/marinade.finance/snapshot-etl:$$TAG"
+      docker run -it --rm -v "$$DATA_DIR":/solana/snapshot --user $(id -u):$(id -g) c29r3/solana-snapshot-finder:latest --snapshot_path /solana/snapshot --max_snapshot_age 20000 --min_download_speed 10 --max_latency 500 | tee ./log.out
+      if grep -q -e 'ERROR.*Could not find a suitable snapshot' ./log.out; then
+        echo "Error to download snapshot. Using RPC to get the snapshot"
+        wget --retry-connrefused --waitretry=1 --tries=10 --timeout=30 -P "$$DATA_DIR" http://api.mainnet-beta.solana.com/snapshot.tar.bz2
+      fi
 
   - wait: ~
 


### PR DESCRIPTION
There are failures in downloading snapshots. It seems the system cannot withstand the requirements for snapshot downloading in the speed of connection, latency and delay of the last snapshot.
It seems that can be connected to the timely voted credits changes https://www.anza.xyz/blog/feature-gate-spotlight-timely-vote-credits (e.g. recommended not to use cmd parameter `--full-snapshot-interval-slots XXXX`).

Changing the parameters helps the snapshot being downloaded and the job not to fail.

Note: the http://api.mainnet-beta.solana.com/snapshot.tar.bz2 still does not work. No idea why.