### PR TITLE
[parser] not working with meteora amm

### DIFF
--- a/src/snapshot/parser/parser.service.ts
+++ b/src/snapshot/parser/parser.service.ts
@@ -147,7 +147,6 @@ export class ParserService {
     ).map(({ lp }) => lp);
     const mercurialStableSwapPoolMint = this.getMercurialStableSwapPoolLps();
     const meteoraVaults = await this.getMercurialMeteoraVaultsLps();
-    const mercurialAmmPoolsLps = await this.getMercurialAmmPoolsLps();
     const solend_reserve_info =
       await this.solanaService.connection.getAccountInfo(
         new PublicKey(SOLEND_RESERVE_ADDR),
@@ -195,7 +194,6 @@ export class ParserService {
         ...raydiumLiquidityPools,
         mercurialStableSwapPoolMint.lp,
         ...meteoraVaults.map((v) => v.lp),
-        ...mercurialAmmPoolsLps.map((v) => v.lp),
         ...(await this.getKaminoShareMintsForFilters()),
       ].join(','),
       whirlpool_pool_address: whirlpools
@@ -208,7 +206,7 @@ export class ParserService {
       solend_reserve_data: solend_reserve_info.data.toString('base64'),
       mango_bank_deposit_index: mango_bank_deposit_index,
       meteora_vaults: meteoraVaults.map((v) => v.vault).join(','),
-      mercurial_pools: mercurialAmmPoolsLps.map((v) => v.pool).join(','),
+      mercurial_pools: '',
     };
   }
 


### PR DESCRIPTION
There is trouble parsing data from (Mercurial) Meteora API for the snapshot parsing.
It seems the API https://app.meteora.ag/amm/pool that we were using to load info about their pools stopped working.
When I check their side or documentation they do not show any info about amm and use term dlmm.
Could they stop with the support of AMM? I was not able to find it when I was briefly checking Twitter.

Anyway, going to skip this data from parsing (for now). We plan to completely remove the DeFi processing from the snapshot manager processing
https://github.com/marinade-finance/solana-snapshot-manager/pull/64