### PR TITLE
[buildkite] fix wrong slot get command

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -123,7 +123,7 @@ steps:
           notification_result="SUCCEEDED"
           notification_color="#00CC00"
         fi
-      - slot=${buildkite-agent meta-data get slot || echo "unknown"}
+      - slot=$(buildkite-agent meta-data get slot || echo "unknown")
       - |
         curl ${SLACK_API} -X POST -H 'Content-Type: application/json; charset=utf-8' \
           -H "Authorization: Bearer $$SLACK_BEARER_TOKEN" -d '{


### PR DESCRIPTION
A small fix in the way of getting slots from meta data. Currently, it is an empty string but it should be a number of the parsed slots to be printed into the slack notification.