### PR TITLE
[pipeline] copy snapshot parser with the same branch as the manager [GEN-6092]

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -39,7 +39,7 @@ steps:
   - label: ":hammer_and_wrench: :rust: Building solana-snapshot-parser"
     commands:
     - source '/var/lib/buildkite-agent/.cargo/env'
-    - git clone git@github.com:marinade-finance/solana-snapshot-parser.git
+    - git clone --depth 1 -b $BUILDKITE_BRANCH git@github.com:marinade-finance/solana-snapshot-parser.git
     - cd solana-snapshot-parser
     - cargo build --release --bin snapshot-parser-tokens-cli
     key: solana-snapshot-parser


### PR DESCRIPTION
There are failures on Solana Snapshot Manager processing. This is only a small addition to build fixing from  https://github.com/marinade-finance/solana-snapshot-parser/pull/14