### PR TITLE
chore: pin GitHub Actions to SHA and ubuntu-24.04

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -4,13 +4,13 @@ on:
 jobs:
   trivy:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy scanner - generate update
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: true
           TRIVY_SKIP_JAVA_DB_UPDATE: true
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Run Trivy scanner - Fail build on Criticial Vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: true
           TRIVY_SKIP_JAVA_DB_UPDATE: true

--- a/.github/workflows/trivy-udpate-cache.yaml
+++ b/.github/workflows/trivy-udpate-cache.yaml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   update-trivy-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup oras
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
 
       - name: Get current date
         id: date
@@ -34,7 +34,7 @@ jobs:
           rm javadb.tar.gz
 
       - name: Cache DBs
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ${{ github.workspace }}/.cache/trivy
           key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable commit SHAs to prevent supply chain attacks
- Replace  with  for reproducible runner environments
- Bump actions to latest available versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)