### PR TITLE
[GEN-8105] endpoints for historical token holding data

### DIFF
--- a/src/snapshot/snapshot.controller.ts
+++ b/src/snapshot/snapshot.controller.ts
@@ -4,15 +4,23 @@ import {
   HttpException,
   HttpStatus,
   Param,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { MsolBalanceDto, VeMNDEBalanceDto } from './snapshot.dto';
+import {
+  MsolBalanceDto,
+  MsolBalanceHistoryItemDto,
+  SnapshotsIntervalDto,
+  VeMNDEBalanceDto,
+  VeMNDEBalanceHistoryItemDto,
+} from './snapshot.dto';
 import { SnapshotService } from './snapshot.service';
 import { StakersService } from 'src/stakers/stakers.service';
+import { HttpDateCacheInterceptor } from 'src/interceptors/date.interceptor';
 
-@Controller('v1/snapshot/latest')
+@Controller('v1/snapshot')
 @ApiTags('Snapshot')
 @UseInterceptors(CacheInterceptor)
 export class SnapshotController {
@@ -21,7 +29,7 @@ export class SnapshotController {
     private readonly stakersService: StakersService,
   ) {}
 
-  @Get('/msol/:pubkey')
+  @Get('/latest/msol/:pubkey')
   @ApiOperation({ summary: 'Fetch mSOL balance for a pubkey' })
   @ApiResponse({
     status: 200,
@@ -41,7 +49,7 @@ export class SnapshotController {
     return result;
   }
 
-  @Get('/vemnde/:pubkey')
+  @Get('/latest/vemnde/:pubkey')
   @ApiOperation({ summary: 'Fetch VeMNDE balance for a pubkey' })
   @ApiResponse({
     status: 200,
@@ -59,5 +67,73 @@ export class SnapshotController {
     }
 
     return result;
+  }
+
+  @Get('/history/msol/:pubkey')
+  @ApiOperation({
+    summary:
+      'Fetch mSOL balance history for a pubkey over a date interval (defaults to the last month)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The records were successfully fetched.',
+    type: [MsolBalanceHistoryItemDto],
+  })
+  @UseInterceptors(HttpDateCacheInterceptor)
+  @CacheTTL(60e3)
+  async getMsolBalanceHistory(
+    @Param('pubkey') pubkey: string,
+    @Query() query: SnapshotsIntervalDto,
+  ): Promise<MsolBalanceHistoryItemDto[]> {
+    if (
+      query.startDate &&
+      query.endDate &&
+      Date.parse(query.startDate) > Date.parse(query.endDate)
+    ) {
+      throw new HttpException(
+        'startDate is later than endDate',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return this.snapshotService.getMsolBalanceHistory(
+      pubkey,
+      query.startDate,
+      query.endDate,
+    );
+  }
+
+  @Get('/history/vemnde/:pubkey')
+  @ApiOperation({
+    summary:
+      'Fetch VeMNDE balance history for a pubkey over a date interval (defaults to the last month)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The records were successfully fetched.',
+    type: [VeMNDEBalanceHistoryItemDto],
+  })
+  @UseInterceptors(HttpDateCacheInterceptor)
+  @CacheTTL(60e3)
+  async getVeMNDEBalanceHistory(
+    @Param('pubkey') pubkey: string,
+    @Query() query: SnapshotsIntervalDto,
+  ): Promise<VeMNDEBalanceHistoryItemDto[]> {
+    if (
+      query.startDate &&
+      query.endDate &&
+      Date.parse(query.startDate) > Date.parse(query.endDate)
+    ) {
+      throw new HttpException(
+        'startDate is later than endDate',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return this.snapshotService.getVeMNDEBalanceHistory(
+      pubkey,
+      query.startDate,
+      query.endDate,
+    );
   }
 }

--- a/src/snapshot/snapshot.dto.ts
+++ b/src/snapshot/snapshot.dto.ts
@@ -1,5 +1,5 @@
 import { IsArray, IsDateString, IsNumber, IsOptional } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsValidDate } from 'src/decorators/snapshots-date.decorator';
 
 export class MsolBalanceDto {
@@ -120,10 +120,19 @@ export class StakeBalanceDto {
 }
 
 export class SnapshotsIntervalDto {
+  @ApiPropertyOptional({
+    description:
+      'Inclusive start of the range (YYYY-MM-DD). Defaults to one month before endDate.',
+    example: '2026-05-01',
+  })
   @IsOptional()
   @IsValidDate()
   startDate: string;
 
+  @ApiPropertyOptional({
+    description: 'Inclusive end of the range (YYYY-MM-DD). Defaults to now.',
+    example: '2026-06-22',
+  })
   @IsOptional()
   @IsValidDate()
   endDate: string;

--- a/src/snapshot/snapshot.dto.ts
+++ b/src/snapshot/snapshot.dto.ts
@@ -30,6 +30,42 @@ export class VeMNDEBalanceDto {
   createdAt: string;
 }
 
+export class MsolBalanceHistoryItemDto {
+  @IsNumber()
+  @ApiProperty()
+  amount: string;
+
+  @IsNumber()
+  @ApiProperty()
+  slot: number;
+
+  @IsDateString()
+  @ApiProperty()
+  createdAt: string;
+
+  @IsDateString()
+  @ApiProperty()
+  snapshotCreatedAt: string;
+}
+
+export class VeMNDEBalanceHistoryItemDto {
+  @IsNumber()
+  @ApiProperty()
+  amount: string;
+
+  @IsNumber()
+  @ApiProperty()
+  slot: number;
+
+  @IsDateString()
+  @ApiProperty()
+  createdAt: string;
+
+  @IsDateString()
+  @ApiProperty()
+  snapshotCreatedAt: string;
+}
+
 export class NativeStakeBalanceDto {
   @IsNumber()
   @ApiProperty()

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -3,8 +3,10 @@ import { sql } from 'slonik';
 import { batches, RdsService } from 'src/rds/rds.service';
 import {
   MsolBalanceDto,
+  MsolBalanceHistoryItemDto,
   NativeStakeBalanceDto,
   VeMNDEBalanceDto,
+  VeMNDEBalanceHistoryItemDto,
 } from './snapshot.dto';
 import { SolanaService } from 'src/solana/solana.service';
 
@@ -130,6 +132,85 @@ export class SnapshotService {
       slot: result.slot,
       createdAt: result.created_at,
     };
+  }
+
+  // Resolves an optional [startDate, endDate] range to a concrete window,
+  // defaulting to the last month when bounds are missing.
+  private resolveHistoryRange(
+    startDate?: string,
+    endDate?: string,
+  ): { startDate: string; endDate: string } {
+    const end = endDate ? new Date(endDate) : new Date();
+    let start: Date;
+    if (startDate) {
+      start = new Date(startDate);
+    } else {
+      start = new Date(end);
+      start.setMonth(start.getMonth() - 1);
+    }
+    return { startDate: start.toISOString(), endDate: end.toISOString() };
+  }
+
+  async getMsolBalanceHistory(
+    owner: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<MsolBalanceHistoryItemDto[]> {
+    const range = this.resolveHistoryRange(startDate, endDate);
+    this.logger.log(
+      `Fetching getMsolBalanceHistory for owner ${owner} [${range.startDate},${range.endDate}]`,
+    );
+    const result = await this.rdsService.pool.any(sql.unsafe`
+            SELECT msol_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
+            FROM msol_holders
+            INNER JOIN snapshots ON snapshots.snapshot_id = msol_holders.snapshot_id
+            WHERE snapshots.created_at >= ${range.startDate}
+              AND snapshots.created_at <= ${range.endDate}
+              AND msol_holders.owner = ${owner}
+            ORDER BY snapshots.created_at ASC
+        `);
+
+    this.logger.log('Msol holder history fetched', {
+      owner,
+      count: result.length,
+    });
+    return result.map((row) => ({
+      amount: row.amount,
+      slot: row.slot,
+      createdAt: row.created_at,
+      snapshotCreatedAt: row.blocktime,
+    }));
+  }
+
+  async getVeMNDEBalanceHistory(
+    owner: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<VeMNDEBalanceHistoryItemDto[]> {
+    const range = this.resolveHistoryRange(startDate, endDate);
+    this.logger.log(
+      `Fetching getVeMNDEBalanceHistory for owner ${owner} [${range.startDate},${range.endDate}]`,
+    );
+    const result = await this.rdsService.pool.any(sql.unsafe`
+            SELECT vemnde_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
+            FROM vemnde_holders
+            INNER JOIN snapshots ON snapshots.snapshot_id = vemnde_holders.snapshot_id
+            WHERE snapshots.created_at >= ${range.startDate}
+              AND snapshots.created_at <= ${range.endDate}
+              AND vemnde_holders.owner = ${owner}
+            ORDER BY snapshots.created_at ASC
+        `);
+
+    this.logger.log('VeMNDE holder history fetched', {
+      owner,
+      count: result.length,
+    });
+    return result.map((row) => ({
+      amount: row.amount,
+      slot: row.slot,
+      createdAt: row.created_at,
+      snapshotCreatedAt: row.blocktime,
+    }));
   }
 
   async createSnapshot(slot: number): Promise<number> {

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -164,10 +164,10 @@ export class SnapshotService {
             SELECT msol_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
             FROM msol_holders
             INNER JOIN snapshots ON snapshots.snapshot_id = msol_holders.snapshot_id
-            WHERE snapshots.created_at >= ${range.startDate}
-              AND snapshots.created_at <= ${range.endDate}
+            WHERE snapshots.blocktime >= ${range.startDate}
+              AND snapshots.blocktime <= ${range.endDate}
               AND msol_holders.owner = ${owner}
-            ORDER BY snapshots.created_at ASC
+            ORDER BY snapshots.blocktime ASC
         `);
 
     this.logger.log('Msol holder history fetched', {
@@ -195,10 +195,10 @@ export class SnapshotService {
             SELECT vemnde_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
             FROM vemnde_holders
             INNER JOIN snapshots ON snapshots.snapshot_id = vemnde_holders.snapshot_id
-            WHERE snapshots.created_at >= ${range.startDate}
-              AND snapshots.created_at <= ${range.endDate}
+            WHERE snapshots.blocktime >= ${range.startDate}
+              AND snapshots.blocktime <= ${range.endDate}
               AND vemnde_holders.owner = ${owner}
-            ORDER BY snapshots.created_at ASC
+            ORDER BY snapshots.blocktime ASC
         `);
 
     this.logger.log('VeMNDE holder history fetched', {

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -163,11 +163,11 @@ export class SnapshotService {
     const result = await this.rdsService.pool.any(sql.unsafe`
             SELECT msol_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
             FROM msol_holders
-            INNER JOIN snapshots ON snapshots.snapshot_id = msol_holders.snapshot_id
+            INNER JOIN snapshots USING (snapshot_id)
             WHERE snapshots.blocktime >= ${range.startDate}
               AND snapshots.blocktime <= ${range.endDate}
               AND msol_holders.owner = ${owner}
-            ORDER BY snapshots.blocktime ASC
+            ORDER BY snapshots.blocktime
         `);
 
     this.logger.log('Msol holder history fetched', {
@@ -194,11 +194,11 @@ export class SnapshotService {
     const result = await this.rdsService.pool.any(sql.unsafe`
             SELECT vemnde_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
             FROM vemnde_holders
-            INNER JOIN snapshots ON snapshots.snapshot_id = vemnde_holders.snapshot_id
+            INNER JOIN snapshots USING (snapshot_id)
             WHERE snapshots.blocktime >= ${range.startDate}
               AND snapshots.blocktime <= ${range.endDate}
               AND vemnde_holders.owner = ${owner}
-            ORDER BY snapshots.blocktime ASC
+            ORDER BY snapshots.blocktime
         `);
 
     this.logger.log('VeMNDE holder history fetched', {


### PR DESCRIPTION
Added historical data endpoints for token holdings:

`/v1/snapshot/history/msol/{pubkey}?startDate=x&endDate=y
`
`/v1/snapshot/history/vemnde/{pubkey}?startDate=x&endDate=y`