### PR TITLE
fix(msol/mnde): [GEN-8404]: return explicit zeros in balance history when balance drops to 0

### DIFF
--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -160,13 +160,32 @@ export class SnapshotService {
     this.logger.log(
       `Fetching getMsolBalanceHistory for owner ${owner} [${range.startDate},${range.endDate}]`,
     );
+    // The parser only stores rows for wallets that hold mSOL at snapshot
+    // time, so a wallet whose balance drops to 0 (sold, or moved into
+    // protocol custody, e.g. lending collateral) silently disappears from
+    // subsequent snapshots. Consumers carrying the last observation forward
+    // then render the stale balance indefinitely. Gap-fill at read time:
+    // for every snapshot in range taken since the wallet first appeared,
+    // return the stored amount, or an explicit 0 when the wallet is absent.
+    // Wallets that never held mSOL still return no rows (first_seen is
+    // NULL, which filters out every snapshot).
     const result = await this.rdsService.pool.any(sql.unsafe`
-            SELECT msol_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
-            FROM msol_holders
-            INNER JOIN snapshots USING (snapshot_id)
+            WITH first_seen AS (
+                SELECT MIN(snapshots.blocktime) AS blocktime
+                FROM msol_holders
+                INNER JOIN snapshots USING (snapshot_id)
+                WHERE msol_holders.owner = ${owner}
+            )
+            SELECT COALESCE(msol_holders.amount, 0) AS amount,
+                   snapshots.slot, snapshots.created_at, snapshots.blocktime
+            FROM snapshots
+            CROSS JOIN first_seen
+            LEFT JOIN msol_holders
+                   ON msol_holders.snapshot_id = snapshots.snapshot_id
+                  AND msol_holders.owner = ${owner}
             WHERE snapshots.blocktime >= ${range.startDate}
               AND snapshots.blocktime <= ${range.endDate}
-              AND msol_holders.owner = ${owner}
+              AND snapshots.blocktime >= first_seen.blocktime
             ORDER BY snapshots.blocktime
         `);
 
@@ -191,13 +210,25 @@ export class SnapshotService {
     this.logger.log(
       `Fetching getVeMNDEBalanceHistory for owner ${owner} [${range.startDate},${range.endDate}]`,
     );
+    // Same gap-fill semantics as getMsolBalanceHistory: absence from an
+    // existing snapshot after the wallet's first appearance is an explicit 0.
     const result = await this.rdsService.pool.any(sql.unsafe`
-            SELECT vemnde_holders.amount, snapshots.slot, snapshots.created_at, snapshots.blocktime
-            FROM vemnde_holders
-            INNER JOIN snapshots USING (snapshot_id)
+            WITH first_seen AS (
+                SELECT MIN(snapshots.blocktime) AS blocktime
+                FROM vemnde_holders
+                INNER JOIN snapshots USING (snapshot_id)
+                WHERE vemnde_holders.owner = ${owner}
+            )
+            SELECT COALESCE(vemnde_holders.amount, 0) AS amount,
+                   snapshots.slot, snapshots.created_at, snapshots.blocktime
+            FROM snapshots
+            CROSS JOIN first_seen
+            LEFT JOIN vemnde_holders
+                   ON vemnde_holders.snapshot_id = snapshots.snapshot_id
+                  AND vemnde_holders.owner = ${owner}
             WHERE snapshots.blocktime >= ${range.startDate}
               AND snapshots.blocktime <= ${range.endDate}
-              AND vemnde_holders.owner = ${owner}
+              AND snapshots.blocktime >= first_seen.blocktime
             ORDER BY snapshots.blocktime
         `);
 


### PR DESCRIPTION
## Problem

The parser only stores rows for wallets that **hold** mSOL/veMNDE at snapshot time. When the balance drops to 0 (sold, unstaked, or moved into protocol custody — e.g. lending collateral, see Maks's Jupiter Lend repro), the wallet silently disappears from subsequent snapshots. `/v1/snapshot/history/{msol,vemnde}/{pubkey}` then stops emitting samples instead of reporting `0`, and consumers carrying the last observation forward (portfolio chart) render the stale balance indefinitely.

Affected example wallets: `Daq4W5wUTNw7sRXxFvLruk13wjpedVcgBB4rjTzx3DhK`, `GQP9XKoRfwo229MA8iDq8GsC4piAruxrg578QbTNQuqD`.

## Fix

Gap-fill at read time in the two history queries: for every snapshot in range taken **since the wallet's first appearance**, return the stored amount, or an explicit `0` when the wallet is absent (`LEFT JOIN … COALESCE(amount, 0)` against the `snapshots` calendar — same pattern the stakers endpoints already use).

Properties:
- **No storage or writer changes** — zeros are synthesized from data already present (absence from an existing snapshot ⇒ balance 0)
- **Retroactive immediately** — past exits and exit-then-rebuy gaps get their zeros on deploy, no backfill
- **No false zeros during pipeline downtime** — absence only counts as 0 where a snapshot row actually exists
- **Wallets that never held the token** still return no rows (`first_seen` is NULL)
- Other endpoints (votes, stakers, latest) and their consumers (DS scoring, delegation-strategy) untouched

## Notes for review

- Suggest deploying to `snapshots-api-dev` first and sanity-checking one affected wallet's history plus one `/v1/votes/msol/latest` response.
- Response size grows for long-exited wallets (a zero row per snapshot in range); default range is one month, so bounded.
- Ticket: [GEN-8404](https://app.notion.com/p/39de465715a48181a8f5fa561eda9a83)

## Testing

- `tsc` clean, `gts lint` clean, `jest` 14/14 passing
- SQL semantics verified against the live schema (`amount NUMERIC`, `snapshots.blocktime` calendar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance history results for mSOL and veMNDE holders.
  * History now includes zero-balance entries for snapshots after a wallet’s first appearance when no balance is recorded, providing a complete time series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->