### PR TITLE
[GEN-8711] Stage cargo binary at target/release for CARGO_TARGET_DIR-aware Buildkite agents

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -88,14 +88,7 @@ steps:
     - git clone --depth 1 -b $BUILDKITE_BRANCH git@github.com:marinade-finance/solana-snapshot-parser.git
     - cd solana-snapshot-parser
     - cargo build --release --bin snapshot-parser-tokens-cli
-    - |
-      # The agent may set CARGO_TARGET_DIR to a shared host cache dir; stage the
-      # binary back to ./target/release so the artifact paths stay unchanged.
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/snapshot-parser-tokens-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/snapshot-parser-tokens-cli'
     key: solana-snapshot-parser
     artifact_paths:
       - solana-snapshot-parser/target/release/snapshot-parser-tokens-cli

--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -88,6 +88,14 @@ steps:
     - git clone --depth 1 -b $BUILDKITE_BRANCH git@github.com:marinade-finance/solana-snapshot-parser.git
     - cd solana-snapshot-parser
     - cargo build --release --bin snapshot-parser-tokens-cli
+    - |
+      # The agent may set CARGO_TARGET_DIR to a shared host cache dir; stage the
+      # binary back to ./target/release so the artifact paths stay unchanged.
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/snapshot-parser-tokens-cli" target/release/
+      fi
     key: solana-snapshot-parser
     artifact_paths:
       - solana-snapshot-parser/target/release/snapshot-parser-tokens-cli


### PR DESCRIPTION
Buildkite agents will soon export `CARGO_TARGET_DIR` globally (agent `environment` hook pointing at a host build cache under `/mnt/storage-1/cargo-target/<pipeline>-<repo>-<commit>-<rustc-hash>`), so `cargo build` output will no longer land in the checkout's `target/release`.

This adds a staging block in `scraper/buildkite.yaml` after the in-tree `cargo build --release --bin snapshot-parser-tokens-cli` (which runs inside the cloned `solana-snapshot-parser` directory): when `CARGO_TARGET_DIR` is set, the binary is copied back into that clone's `target/release/` so the `solana-snapshot-parser/target/release/...` artifact path and downstream download/run keep working unchanged. When the variable is unset the block is a no-op, so this is safe to merge ahead of the hook.

References are `$$`-escaped for job-runtime expansion, matching the file's existing convention. Verified: YAML parses, the block rides the same joined command script as the preceding `cd` (a pattern this step already relies on), path consistent across stage/upload/download/run sites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEGbV86P2XNoY8Jq6CMg6D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build artifact handling when using a shared compilation cache.
  * Preserved the existing release artifact location for consistent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->