### PR TITLE
[buildkite] configurability of parser branch

### DIFF
--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -85,7 +85,7 @@ steps:
   - label: ":hammer_and_wrench: :rust: Building solana-snapshot-parser"
     commands:
     - source '/var/lib/buildkite-agent/.cargo/env'
-    - git clone --depth 1 -b $BUILDKITE_BRANCH git@github.com:marinade-finance/solana-snapshot-parser.git
+    - git clone --depth 1 -b "$${PARSER_BRANCH:-$$BUILDKITE_BRANCH}" git@github.com:marinade-finance/solana-snapshot-parser.git
     - cd solana-snapshot-parser
     - cargo build --release --bin snapshot-parser-tokens-cli
     - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/snapshot-parser-tokens-cli'
@@ -148,9 +148,10 @@ steps:
       - pnpm install --frozen-lockfile
       - pnpm run cli -- parse --sqlite "$${snapshot_dir}/snapshot.db" --csv-output "$${snapshot_dir}/snapshot.csv" --slot "$$slot" --psql-output
     key: 'parsing-snapshot'
+    timeout_in_minutes: 240
     retry:
       automatic:
-        - limit: 4
+        - limit: 1
 
   - wait: ~
 

--- a/scraper/buildkite.yaml
+++ b/scraper/buildkite.yaml
@@ -31,6 +31,7 @@ steps:
       \`\`\`
       SLEEP_TIME=$$sleep_time
       NOTIFY_FEED=$${NOTIFY_FEED:-false}
+      PARSER_BRANCH=$${PARSER_BRANCH:-$$BUILDKITE_BRANCH}
       \`\`\`
       EOF
 
@@ -87,6 +88,7 @@ steps:
     - source '/var/lib/buildkite-agent/.cargo/env'
     - git clone --depth 1 -b "$${PARSER_BRANCH:-$$BUILDKITE_BRANCH}" git@github.com:marinade-finance/solana-snapshot-parser.git
     - cd solana-snapshot-parser
+    - git log -1 --format='parser commit %H (%ci) %s'
     - cargo build --release --bin snapshot-parser-tokens-cli
     - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/snapshot-parser-tokens-cli'
     key: solana-snapshot-parser


### PR DESCRIPTION
* not waiting so long to report an issue - one rerun should be enough to cover some hiccups, but it shouldn't stay running for a whole day

Connnected with changes of parser here: https://github.com/marinade-finance/solana-snapshot-parser/pull/49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Snapshot parsing jobs can now use a specified parser branch when retrying.
  - Build logs now include the parser revision used, improving troubleshooting.
  - Snapshot parsing has a longer execution window of up to 240 minutes.
  - Automatic retries are limited to one attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->